### PR TITLE
Allow send() on Cordova/non-same-origin

### DIFF
--- a/cookies.js
+++ b/cookies.js
@@ -244,7 +244,7 @@ const isStringifiedRegEx = /JSON\.parse\((.*)\)/;
 const isTypedRegEx = /false|true|null|undefined/;
 const deserialize = (string) => {
   if (typeof string !== 'string') {
-    return string;
+    return decode(string);
   }
 
   if (isStringifiedRegEx.test(string)) {

--- a/cookies.js
+++ b/cookies.js
@@ -11,6 +11,7 @@ if (Meteor.isServer) {
 
 const NoOp  = () => {};
 const urlRE = /\/___cookie___\/set/;
+const originRE = /^http:\/\/localhost:12\d\d\d$/;
 const helpers = {
   isUndefined(obj) {
     return obj === void 0;
@@ -22,6 +23,10 @@ const helpers = {
     if (!this.isObject(obj)) return obj;
     return this.isArray(obj) ? obj.slice() : Object.assign({}, obj);
   }
+};
+const setWithCredentials = (xhr) => {
+  xhr.withCredentials = true;
+  return true;
 };
 const _helpers = ['Number', 'Object'];
 for (let i = 0; i < _helpers.length; i++) {
@@ -153,7 +158,7 @@ const antiCircular = (_obj) => {
  * @param {String} name
  * @param {String} val
  * @param {Object} [options]
- * @return { cookieString: String, sanitizedValue: Mixed }
+ * @return String
  * @summary
  * Serialize data into a cookie header.
  * Serialize the a name value pair into a cookie string suitable for
@@ -170,13 +175,11 @@ const serialize = (key, val, opt = {}) => {
     name = key;
   }
 
-  let sanitizedValue = val;
   let value = val;
   if (!helpers.isUndefined(value)) {
     if (helpers.isObject(value) || helpers.isArray(value)) {
       const stringified = antiCircular(value);
       value = encode(`JSON.parse(${stringified})`);
-      sanitizedValue = JSON.parse(stringified);
     } else {
       value = encode(value);
       if (value && !fieldContentRegExp.test(value)) {
@@ -234,7 +237,7 @@ const serialize = (key, val, opt = {}) => {
     pairs.push('SameSite');
   }
 
-  return { cookieString: pairs.join('; '), sanitizedValue };
+  return pairs.join('; ');
 };
 
 const isStringifiedRegEx = /JSON\.parse\((.*)\)/;
@@ -320,8 +323,8 @@ class __cookies {
       if (helpers.isNumber(this.TTL) && opts.expires === undefined) {
         opts.expires = new Date(+new Date() + this.TTL);
       }
-      const { cookieString, sanitizedValue } = serialize(key, value, opts);
-      this.cookies[key] = sanitizedValue;
+      const cookieString = serialize(key, value, opts);
+      this.cookies[key] = cookieString;
       if (Meteor.isClient) {
         document.cookie = cookieString;
       } else {
@@ -351,7 +354,7 @@ class __cookies {
    */
   remove(key, path = '/', domain = '') {
     if (key && this.cookies.hasOwnProperty(key)) {
-      const { cookieString } = serialize(key, '', {
+      const cookieString = serialize(key, '', {
         domain,
         path,
         expires: new Date(0)
@@ -417,14 +420,23 @@ class __cookies {
   send(cb = NoOp) {
     if (Meteor.isServer) {
       cb(new Meteor.Error(400, 'Can\'t run `.send()` on server, it\'s Client only method!'));
+      return;
     }
 
     if (this.runOnServer) {
-      HTTP.get(`${window.__meteor_runtime_config__.ROOT_URL_PATH_PREFIX || ''}/___cookie___/set`, cb);
+      let path = (window.__meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '') + '/___cookie___/set';
+      let query = ``;
+      if (Meteor.isCordova) {
+        path = Meteor.absoluteUrl('___cookie___/set');
+        const cookies = this.keys().map(key => `cookie=${encodeURIComponent(this.cookies[key])}`);
+        query = `?${cookies.join('&')}`;
+      }
+
+      HTTP.get(`${path}${query}`, { beforeSend: setWithCredentials }, cb);
     } else {
       cb(new Meteor.Error(400, 'Can\'t send cookies on server when `runOnServer` is false.'));
     }
-    return void 0;
+    return;
   }
 }
 
@@ -475,13 +487,22 @@ class Cookies extends __cookies {
           if (opts.auto) {
             WebApp.connectHandlers.use((req, res, next) => {
               if (urlRE.test(req._parsedUrl.path)) {
-                if (req.headers && req.headers.cookie) {
+                if (originRE.test(req.headers.origin)) {
+                  res.setHeader('Access-Control-Allow-Credentials', 'true');
+                  res.setHeader('Access-Control-Allow-Origin', req.headers.origin);
+                }
+
+                if (req.query.cookie) {
+                  const cookies = helpers.isArray(req.query.cookie) ? req.query.cookie : [req.query.cookie];
+                  res.setHeader('Set-Cookie', cookies);
+                } else if (req.headers.cookie) {
                   const cookiesObject = parse(req.headers.cookie);
                   const cookiesKeys   = Object.keys(cookiesObject);
                   const cookiesArray  = [];
 
                   for (let i = 0; i < cookiesKeys.length; i++) {
-                    const { cookieString } = serialize(cookiesKeys[i], cookiesObject[cookiesKeys[i]]);
+                    let cookieString = serialize(cookiesKeys[i], cookiesObject[cookiesKeys[i]]);
+                    cookieString += '; Path=/';
                     if (!cookiesArray.includes(cookieString)) {
                       cookiesArray.push(cookieString);
                     }


### PR DESCRIPTION
This PR enables `cookies.send()` on Cordova (iOS/Android), where it was before unusable because Cookies never reached the non-origin domain `$ROOT_URL`, regardless of whether `.send()` was called or not since `document.cookie` referred only to the `localhost:12008` "proxy" domain and the `.send()` request was also sent there and was unanswered.

Some notable changes:
- `this.cookies` now stores the **cookieString**; not the sanitized Value. This is necessary because after setting attributes like `Path=/` in `document.cookie`, these attributes are not accessible by the client anymore, i.e. they *do not show up* in `document.cookie`, and therefore need to be tracked independently.
- `send()` passes the Cookies by URI-string because they otherwise couldn't reach the server
- if `Meteor.isCordova` `send()` reaches out to `Meteor.absoluteUrl()` instead of the default, which is `localhost:12008` in these cases, where the server cannot reply and instead index.html is served.
- `Access-Control-Allow-Origin: http://localhost:12008` and `Access-Control-Allow-Credentials: true` are set on the `___cookie___/set` route.

The overall API remains consistent and as far as I could tell `meteor test-packages` agrees that nothing got hurt.