### PR TITLE
add allowedCordovaOrigin in order to whitelist cookie requests from Cordova

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Create new instance of Cookies
 - `opts.TTL` {*Number*|*Boolean*} - Default cookies expiration time (max-age) in milliseconds, by default - `false` (*session, no TTL*)
 - `opts.runOnServer` {*Boolean*} - Set to `false` to avoid server usage (by default - `true`)
 - `opts.allowQueryStringCookies` {*Boolean*} - Allow passing Cookies in a query string (in URL). Primary should be used only in *Cordova* environment. Note: this option will be used only on Cordova
-- `opts.allowedCordovaOrigin` {*String*} - [*Server*] Allow setting Cookies from that specific origin which in Meteor/Cordova is localhost:12XXX
+- `opts.allowedCordovaOrigin` {*Regex*} - [*Server*] Allow setting Cookies from that specific origin which in Meteor/Cordova is localhost:12XXX
 
 ```js
 import { Cookies } from 'meteor/ostrio:cookies';

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Create new instance of Cookies
 - `opts.TTL` {*Number*|*Boolean*} - Default cookies expiration time (max-age) in milliseconds, by default - `false` (*session, no TTL*)
 - `opts.runOnServer` {*Boolean*} - Set to `false` to avoid server usage (by default - `true`)
 - `opts.allowQueryStringCookies` {*Boolean*} - Allow passing Cookies in a query string (in URL). Primary should be used only in *Cordova* environment. Note: this option will be used only on Cordova
+- `opts.allowedCordovaOrigin` {*String*} - [*Server*] Allow setting Cookies from that specific origin which in Meteor/Cordova is localhost:12XXX
 
 ```js
 import { Cookies } from 'meteor/ostrio:cookies';
@@ -95,7 +96,15 @@ Returns an array of all readable cookies from this location
 
 ### `cookies.send([callback])` [*Client*]
 
-Send all current cookies to server
+Send all current cookies to server.
+
+When `opts.allowQueryStringCookies` is `true` on both `Client` and `Server` and `opts.allowedCordovaOrigin`
+matches the client's local webserver address (e.g. `localhost:12XXX` - Meteor/Cordova connects through `localhost:12XXX` for outgoing requests)
+this also instructs the server to respond with the requested cookies (sent as GET-Parameters) in the response as `Set-Cookie`-header.
+
+The reason for this *workaround* is the general lack of cookie support in Meteor/Cordova when setting in the client - but cookies set by the server are always sent along with every request.
+
+*Please make sure that requests which should include cookies must have [withCredentials](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials) enabled*
 
 ## Examples:
 

--- a/cookies.js
+++ b/cookies.js
@@ -13,7 +13,6 @@ const NoOp  = () => {};
 const urlRE = /\/___cookie___\/set/;
 const rootUrl = Meteor.isServer ? process.env.ROOT_URL : (window.__meteor_runtime_config__.ROOT_URL || window.__meteor_runtime_config__.meteorEnv.ROOT_URL || false);
 const mobileRootUrl = Meteor.isServer ? process.env.MOBILE_ROOT_URL : (window.__meteor_runtime_config__.MOBILE_ROOT_URL || window.__meteor_runtime_config__.meteorEnv.MOBILE_ROOT_URL || false);
-const originRE = new RegExp(`^https?:\/\/(localhost:12\\d\\d\\d${rootUrl ? ('|' + rootUrl) : ''}${mobileRootUrl ? ('|' + mobileRootUrl) : ''})$`);
 
 const helpers = {
   isUndefined(obj) {
@@ -277,6 +276,7 @@ const deserialize = (string) => {
  * @param opts.runOnServer {Boolean} - Expose Cookies class to Server
  * @param opts.response {http.ServerResponse|Object} - This object is created internally by a HTTP server
  * @param opts.allowQueryStringCookies {Boolean} - Allow passing Cookies in a query string (in URL). Primary should be used only in Cordova environment
+ * @param opts.allowedCordovaOrigin {String} - [Server] Allow setting Cookies from that specific origin which in Meteor/Cordova is localhost:12XXX
  * @summary Internal Class
  */
 class __cookies {
@@ -285,6 +285,9 @@ class __cookies {
     this.response = opts.response || false;
     this.runOnServer = opts.runOnServer || false;
     this.allowQueryStringCookies = opts.allowQueryStringCookies || false;
+    this.allowedCordovaOrigin = opts.allowedCordovaOrigin ? `http://${opts.allowedCordovaOrigin}` : '';
+
+    this.originRE = new RegExp(`^https?:\/\/(${opts.allowedCordovaOrigin ? opts.allowedCordovaOrigin : ''}${rootUrl ? ('|' + rootUrl) : ''}${mobileRootUrl ? ('|' + mobileRootUrl) : ''})$`);
 
     if (helpers.isObject(opts._cookies)) {
       this.cookies = opts._cookies;
@@ -497,6 +500,7 @@ const __middlewareHandler = (request, response, opts) => {
  * @param opts.handler {Function} - [Server] Middleware handler
  * @param opts.runOnServer {Boolean} - Expose Cookies class to Server
  * @param opts.allowQueryStringCookies {Boolean} - Allow passing Cookies in a query string (in URL). Primary should be used only in Cordova environment
+ * @param opts.allowedCordovaOrigin {String} - [Server] Allow setting Cookies from that specific origin which in Meteor/Cordova is localhost:12XXX
  * @summary Main Cookie class
  */
 class Cookies extends __cookies {
@@ -521,14 +525,17 @@ class Cookies extends __cookies {
         if (opts.auto) {
           WebApp.connectHandlers.use((req, res, next) => {
             if (urlRE.test(req._parsedUrl.path)) {
-              if (originRE.test(req.headers.origin)) {
+              if (this.originRE.test(req.headers.origin)) {
                 res.setHeader('Access-Control-Allow-Credentials', 'true');
                 res.setHeader('Access-Control-Allow-Origin', req.headers.origin);
               }
 
               const cookiesArray = [];
               let cookiesObject = {};
-              if (opts.allowQueryStringCookies && req.query.___cookies___) {
+              if (this.allowedCordovaOrigin
+                && req.headers.origin
+                && this.allowedCordovaOrigin === req.headers.origin
+                && opts.allowQueryStringCookies && req.query.___cookies___) {
                 cookiesObject = parse(decodeURIComponent(req.query.___cookies___));
               } else if (req.headers.cookie) {
                 cookiesObject = parse(req.headers.cookie);


### PR DESCRIPTION
As a follow up to
https://github.com/VeliovGroup/Meteor-Cookies/pull/14#issuecomment-544131954
this PR adds `opts.allowedCordovaOrigin` in order to control which requests should be allowed to instruct the server to respond with the requested cookies.

@dr-dimitru Is this what you had in mind?

In addition I don't think that `allowQueryStringCookies` is actually needed. On the server this full-fills the security related topics (don't use `opts.allowedCordovaOrigin` and your server won't respond). Just on the client it makes sense as this also controls if cookies should be requested at all when using `send()`.

Generally I think this should be done in `send()` it self, like options you could pass. But this would either result in a weird API (`send(cb, opt)`) or a breaking change.

My recommendation is to remove `allowQueryStringCookies` from server related code and to use it only in the client.

If you want this change as well let me know.